### PR TITLE
Add Markdown issue templates and auto-type workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-feature.md
+++ b/.github/ISSUE_TEMPLATE/1-feature.md
@@ -1,0 +1,23 @@
+---
+name: Feature
+about: New Feature
+title: ''
+labels: ''
+assignees: ''
+---
+
+### Description
+
+<!-- Add description.. -->
+
+### Acceptance criteria
+
+<!-- Add acceptance criteria.. -->
+
+### Technical specification
+
+<!-- Add technical specification.. -->
+
+### QA specification
+
+<!-- For BE tasks, please add: DB changes (table, column, …) and migration guidelines; Endpoint changes and migration guidelines; For FE/App tasks, please add build and App info. -->

--- a/.github/ISSUE_TEMPLATE/2-task.md
+++ b/.github/ISSUE_TEMPLATE/2-task.md
@@ -1,0 +1,11 @@
+---
+name: Task
+about: New Task
+title: ''
+labels: ''
+assignees: ''
+---
+
+### Task specification
+
+<!-- We need to.. -->

--- a/.github/ISSUE_TEMPLATE/3-bug.md
+++ b/.github/ISSUE_TEMPLATE/3-bug.md
@@ -1,0 +1,23 @@
+---
+name: Bug
+about: New Bug
+title: ''
+labels: ''
+assignees: ''
+---
+
+### Affected product(s) and version(s)
+
+<!-- Affected product(s) and version(s) -->
+
+### Environment
+
+<!-- Environment -->
+
+### Steps to reproduce, current result, expected result
+
+<!-- Steps to reproduce, current result, expected result.. -->
+
+### Log output
+
+<!-- Log snippets.. -->

--- a/.github/workflows/set-issue-type.yml
+++ b/.github/workflows/set-issue-type.yml
@@ -1,0 +1,58 @@
+name: Set Issue Type from Template
+on:
+  issues:
+    types: [opened]
+  workflow_call:
+    inputs:
+      issue-node-id:
+        required: true
+        type: string
+      issue-body:
+        required: true
+        type: string
+
+permissions:
+  issues: write
+
+jobs:
+  set-type:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Detect template and set issue type
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NODE_ID: ${{ inputs.issue-node-id || github.event.issue.node_id }}
+          ISSUE_BODY: ${{ inputs.issue-body || github.event.issue.body }}
+        run: |
+          if echo "$ISSUE_BODY" | grep -q "^### Description"; then
+            TYPE_ID="IT_kwDOAJoha84AEoBa"
+            TYPE_NAME="Feature"
+          elif echo "$ISSUE_BODY" | grep -q "^### Task specification"; then
+            TYPE_ID="IT_kwDOAJoha84AEoBV"
+            TYPE_NAME="Task"
+          elif echo "$ISSUE_BODY" | grep -q "^### Affected product"; then
+            TYPE_ID="IT_kwDOAJoha84AEoBX"
+            TYPE_NAME="Bug"
+          elif echo "$ISSUE_BODY" | grep -q "^### Epic specification"; then
+            TYPE_ID="IT_kwDOAJoha84BeLNu"
+            TYPE_NAME="Epic"
+          elif echo "$ISSUE_BODY" | grep -q "^### Initiative specification"; then
+            TYPE_ID="IT_kwDOAJoha84B3pA8"
+            TYPE_NAME="Initiative"
+          else
+            echo "No known template fingerprint detected — skipping."
+            exit 0
+          fi
+
+          echo "Detected: $TYPE_NAME ($TYPE_ID)"
+
+          gh api graphql -f query="
+            mutation {
+              updateIssue(input: {
+                id: \"$ISSUE_NODE_ID\",
+                issueTypeId: \"$TYPE_ID\"
+              }) {
+                issue { number issueType { name } }
+              }
+            }
+          "

--- a/.github/workflows/set-issue-type.yml
+++ b/.github/workflows/set-issue-type.yml
@@ -56,3 +56,22 @@ jobs:
               }
             }
           "
+
+      - name: Add to Tracking project
+        # Only runs for direct issues: opened trigger, not workflow_call
+        if: github.event_name == 'issues'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NODE_ID: ${{ github.event.issue.node_id }}
+        run: |
+          gh api graphql -f query="
+            mutation {
+              addProjectV2ItemById(input: {
+                projectId: \"PVT_kwDOAJoha84AujBf\",
+                contentId: \"$ISSUE_NODE_ID\"
+              }) {
+                item { id }
+              }
+            }
+          "
+          echo "Added to Tracking project"

--- a/.github/workflows/set-issue-type.yml
+++ b/.github/workflows/set-issue-type.yml
@@ -24,6 +24,12 @@ jobs:
           ISSUE_NODE_ID: ${{ inputs.issue-node-id || github.event.issue.node_id }}
           ISSUE_BODY: ${{ inputs.issue-body || github.event.issue.body }}
         run: |
+          CURRENT_TYPE=$(gh api graphql -f query="{ node(id: \"$ISSUE_NODE_ID\") { ... on Issue { issueType { name } } } }" --jq '.data.node.issueType.name // empty')
+          if [ -n "$CURRENT_TYPE" ]; then
+            echo "Issue type already set to '$CURRENT_TYPE' — skipping."
+            exit 0
+          fi
+
           if echo "$ISSUE_BODY" | grep -q "^### Description"; then
             TYPE_ID="IT_kwDOAJoha84AEoBa"
             TYPE_NAME="Feature"

--- a/.github/workflows/set-issue-type.yml
+++ b/.github/workflows/set-issue-type.yml
@@ -56,22 +56,3 @@ jobs:
               }
             }
           "
-
-      - name: Add to Tracking project
-        # Only runs for direct issues: opened trigger, not workflow_call
-        if: github.event_name == 'issues'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_NODE_ID: ${{ github.event.issue.node_id }}
-        run: |
-          gh api graphql -f query="
-            mutation {
-              addProjectV2ItemById(input: {
-                projectId: \"PVT_kwDOAJoha84AujBf\",
-                contentId: \"$ISSUE_NODE_ID\"
-              }) {
-                item { id }
-              }
-            }
-          "
-          echo "Added to Tracking project"


### PR DESCRIPTION
## Summary

Adds Markdown equivalents of the existing YAML issue templates and a GitHub Actions workflow that automatically sets the issue type and adds the issue to the Tracking project.

### Changes

#### Issue templates (MD)
- `1-feature.md` — Feature template (fingerprint: `### Description`)
- `2-task.md` — Task template (fingerprint: `### Task specification`)
- `3-bug.md` — Bug template (fingerprint: `### Affected product`)

The MD templates are **equivalents of the existing YAML templates** — same sections, same structure, same field labels. The only difference is that MD templates cannot carry metadata (assignees, labels, projects) that YAML templates support natively. YAML templates take precedence in the web UI when names match; MD templates serve the CLI path, intended primarily for AI usage, namely GitHub Copilot.

#### Workflow
- `set-issue-type.yml` — On every new issue:
  1. Detects the template fingerprint from the issue body and sets the correct issue type (Feature / Task / Bug / Epic / Initiative) via GraphQL.
  2. Automatically adds the issue to the **Tracking** project (wultra/#43).

  Supports both `issues: opened` and `workflow_call` triggers (reusable by other repos). The Tracking assignment runs only on direct `issues: opened` — callers manage their own project assignment.